### PR TITLE
Update 05-04_awards-history.md

### DIFF
--- a/05_History/05-04_awards-history.md
+++ b/05_History/05-04_awards-history.md
@@ -40,6 +40,7 @@ Sustained Service Awards are given to recognize service to the Society of Califo
 | 2019                                   | David Keller             |
 | 2020                                   | [not awarded]            |
 | 2021                                   | Ellen Jarosz             |
+| 2022                                   | Eric Milenkiewicz        |
 
 ## Archives Appreciation Award
 Sponsored by Metal Edge, Inc, the Archives Appreciation Award is presented to an agency, organization, or institution which has provided support for archival programs. This includes both processing and reference programs as well as exhibit presentations. However, agencies, organizations or institutions with in-house archival programs must show support of these programs.
@@ -66,6 +67,7 @@ Sponsored by Metal Edge, Inc, the Archives Appreciation Award is presented to an
 | 2019 | Los Angeles Archivists Collective                                |
 | 2020 | [not awarded]                                                    |
 | 2021 | L.A. as Subject                                                  |
+| 2022 | Anaheim Public Library and Heritage Center                       |
 
 ## James V. Mink Scholarship Award
 Scholarships are awarded each year in honor of James V. Mink, long-time archivist at UCLA and the first President of the Society of California Archivists. The Mink Scholarship promotes the professional development of students preparing to become archivists or archivists who have recently graduated by providing support for attendance at the AGM and a pre-conference workshop.
@@ -107,6 +109,8 @@ Scholarships are awarded each year in honor of James V. Mink, long-time archivis
 | 2019 | Ashley Evans Bandy                |
 | 2020 | Jiarui Sun                        |
 | 2021 | Grace Muñoz                       |
+| 2022 | Dieter Mackenbach                 |
+| 2022 | Brock Stuessi                     |
 
 ## Career Achievement Award (established 2011)
 
@@ -121,6 +125,7 @@ Scholarships are awarded each year in honor of James V. Mink, long-time archivis
 | 2019 | Jim Hofer         |
 | 2020 | [not awarded]     |
 | 2021 | Gabriele Carey and Catherine Powell |
+| 2022 | Brian Tingle      |
 
 ## Lynn A. Bonfield Professional Development Award (established 2018)
 
@@ -138,4 +143,4 @@ Scholarships are awarded each year in honor of James V. Mink, long-time archivis
 
 ***
 
-_Revision history: 1/10 lo, 3/11 lo, 7/12 tep, 5/14 tep, 01/2017 llc, 06/2017 llc, 05/2019 llc, 01/2022 ck_
+_Revision history: 1/10 lo, 3/11 lo, 7/12 tep, 5/14 tep, 01/2017 llc, 06/2017 llc, 05/2019 llc, 01/2022 ck, 03/23 lm_


### PR DESCRIPTION
Updated to include 2022 SCA awardees as required by the Immediate Past President in section 2-6 of the SCA Handbook.