### PR TITLE
Update 05-06_board-alpha.md

### DIFF
--- a/05_History/05-06_board-alpha.md
+++ b/05_History/05-06_board-alpha.md
@@ -38,13 +38,14 @@ title: 5-6 Board of Directors: Alphabetical List
 - Donofrio, John: Secretary/Treasurer 1974-1976
 - Donovan, Lynn B.: Council 1973-1975, Chair, Steering Committee 1971; Ad Hoc Steering Committee 1971
 - Downey, Lynn: President 1995-1996, VP (appointed to fill Hooks term) 1994-1995, Board (resigned/appointed to VP)
-- Dundon Kate: Board 2021-2023
+- Dundon, Kate: Board 2021-2023
 
 - Eason, James: VP 2012-2013, Board 2003-2005; President 2013-2014
 - Evans, Peter A.: Ad Hoc Steering Committee (formation) 1971
 - Ewing-Haley, Susan: Membership 2009-2011, Board 1996-1998
 
 - Flores, Sylvia B.: Council 1972-1973
+- Furnier, Mallory: Board 2022-2024
 
 - Galvin, Edward L.: Board 1993-1995
 - Garner, Carolyn: President 1999-2000, VP 1998-1999, Council (appointed to fill Wexler term) 1991-1993
@@ -67,7 +68,7 @@ title: 5-6 Board of Directors: Alphabetical List
 - Hughes, Maggie: Secretary (2019-2021)
 
 - Idels, Helene: Secretary 2009-2011
-- Ilieva, Polina: Board, 2014-2016
+- Ilieva, Polina: Board 2014-2016
 
 - Jarosz, Ellen: Immediate Past President 2016-2017, President 2015-2016, VP 2014-2015
 - Johnson, Linda: Treasurer 2000-2006 (three terms)
@@ -85,19 +86,20 @@ title: 5-6 Board of Directors: Alphabetical List
 - Lewis, Dan: President 2006-2007, VP 2005-2006, Board 2002-2004
 - Lindberg, Lori: Board 2008-2010
 - Lowell, Waverly B.: President 1989-1990, VP 1988-1989, Council 1983-1985
-- Luftschein, Susan: board 2020-2022
+- Luftschein, Susan: Board 2020-2022
 
 - Mackay-Collins, Dorothy: Secretary 1991-1993
 - McLendon, Rose: Membership 2010-2011
 - Marino, Chris: Board 2016-2018
-- Marshall, Leilani: President 2021-2022, VP 2020-2021, Treasurer 2012-2016 (two terms)
+- Marshall, Leilani: Immediate Past President 2022-2023, President 2021-2022, VP 2020-2021, Treasurer 2012-2016 (two terms)
 - Martinez, Jennifer L.: President 2004-2005, VP 2003-2004, Board 2000-2002
 - Merrill, Leslie O.: Council 1972-1974
 - Metzer, Laren: President 1998-1999, VP 1997-1998, Council 1983-1985
-- Michels, Lara: Treasurer (2019-2021)
+- Michels, Lara: Treasurer 2020-2022
 - Milenkiewicz, Eric: Immediate Past President, 2020-2021, President 2019-2020, VP 2018-2019, Membership 2011-2015 (two terms)
 - Miller, Lisa: President 2012-2013, VP 2011-2012, Membership 2005-2007
 - Mink, James V.: President 1972-1974, Ad Hoc Steering Committee 1971
+- Mix, Lisa: VP 2022-2023
 - Mora, Teresa: Immediate Past President 2019-2020, President 2018-2019, VP 2017-2018
 - Morin, Jacqueline: Secretary 2007-2009, Board (appointed to fill Keats term) 2001
 - Mueller, Jane: Secretary 1983-1985
@@ -113,7 +115,8 @@ title: 5-6 Board of Directors: Alphabetical List
 - Palmer, Patricia: VP 1975-1977, Ad Hoc Steering Committee 1971
 - Panek, Tracey: Secretary 2011-2015 (two terms)
 - Phillips, Liz: Treasurer 2018-2020
-- Posas, Liza: VP 2021-2022, Board 2011-2013
+- Posas, Liza: President 2022-2023, VP 2021-2022, Board 2011-2013
+- Post, Alex: Treasurer 2022-2024
 - Preston, Jean F.: VP 1972-1975, Ad Hoc Steering Committee 1971
 - Pugsley, Sharon: Secretary 1981-1983
 
@@ -161,5 +164,5 @@ title: 5-6 Board of Directors: Alphabetical List
 
 ***
 
-_Revision history: 10/92 jab, 5/93, 4/94 ppa, 7/95 ppa, 6/98 lgr, 1/11 lo, 7/12 tep, 5/14 tep, 01/2017 llc, 06/2017 llc, 06/2018 llc, 04/2019 llc, 05/2019 llc, 01/2022 ck_
+_Revision history: 10/92 jab, 5/93, 4/94 ppa, 7/95 ppa, 6/98 lgr, 1/11 lo, 7/12 tep, 5/14 tep, 01/2017 llc, 06/2017 llc, 06/2018 llc, 04/2019 llc, 05/2019 llc, 01/2022 ck, 03/23 lm_
 


### PR DESCRIPTION
Updated to include 2022 SCA Board members as required by the Immediate Past President in section 2-6 of the SCA Handbook.