### PR TITLE
Update 01-06_sca-code-of-conduct.md

### DIFF
--- a/01_Introductory_Material/01-06_sca-code-of-conduct.md
+++ b/01_Introductory_Material/01-06_sca-code-of-conduct.md
@@ -5,19 +5,40 @@ title: 1-6 SCA Code of Conduct
 
 # 1-6 SCA Code of Conduct
 
-The Society of California Archivists (SCA) is devoted to fostering cooperation and professional development among its members. SCA is committed to providing its members and guests with a welcoming, diverse, and professional community. SCA does not tolerate harassment in any form. The Code of Conduct is meant to ensure that those who participate in SCA Programs[^1] will not be harassed or in turn harass someone else for any reason. All members and guests are entitled to participate in a professional environment regardless of age, color, creed, disability, family relationship, gender identity, gender expression, individual lifestyle, level of experience in the archival field, marital status, military or veteran status, national origin, physical appearance, professional status, race, class, religion, sex, or sexual orientation.
+The Society of California Archivists (SCA) is devoted to fostering cooperation and professional development among its members. We believe that the best problem-solving and critical thinking happens when people with a wide variety of experiences and perspectives come together to work in comfort as peers. We, therefore, expect participants in the SCA community to help create thoughtful and respectful environments where dialogue and exchange can take place. This policy is not intended to constrain responsible scholarly or professional discourse and debate, but to foster an environment where it can thrive in a universally welcoming community setting. Small actions you can take will help us create a culture of trust and accountability. We suggest these Ways of Being^[1]:
 
-SCA is committed to combating implicit and explicit bias, and dismantling structural inequities, such as white supremacy, patriarchy, classism, heteronormativity, and ableism. The SCA community prioritizes marginalized people’s safety over privileged people’s comfort. 
+- listening as much as you speak, and remembering that colleagues may have expertise you are unaware of; 
+- encouraging and yielding the floor to those whose viewpoints may be under-represented in a group; 
+- using welcoming language, for instance by using an individual’s stated pronouns and favoring gender-neutral collective nouns; 
+- accepting critique graciously and offering it constructively; 
+- giving credit where it is due; 
+- seeking concrete ways to make physical spaces and online resources more universally accessible; 
+- and staying alert, as Active Bystanders, to the welfare of those around you.
 
-We believe that the best problem-solving and critical thinking happens when people with a wide variety of experiences and perspectives come together to work in comfort as peers. We, therefore, expect participants in the SCA community to help create thoughtful and respectful environments where dialogue and exchange can take place. This policy is not intended to constrain responsible scholarly or professional discourse and debate, but to foster an environment where it can thrive in a universally welcoming community setting. 
+SCA is committed to providing its members and guests with a welcoming, diverse, and professional community. SCA does not tolerate harassment in any form. The Code of Conduct is meant to ensure that those who participate in SCA Programs^[2] will not be harassed or in turn harass someone else for any reason. All members and guests are entitled to participate in a professional environment regardless of age, income or social class, color, creed, disability, family relationship, gender identity, gender expression, individual lifestyle, level of experience in the archival field, educational background, marital status, military or veteran status, national origin, physical appearance, professional status, race, religion, sex, or sexual orientation. 
 
-SCA will take seriously all good-faith reports of harassment. Harassment may include, but is not limited to, abusive verbal or written comments, unwelcome jokes, discriminatory images, and/or purposeful acts of misgendering in public or online spaces; deliberate intimidation; stalking; sustained disruption of talks or other events; inappropriate physical contact or invasion of physical space; unwelcome sexual attention; and comments that reinforce oppressive power dynamics related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion, national origin, or economic status.
+SCA is committed to combating implicit and explicit bias, and dismantling structural inequities, such as white supremacy, racism, patriarchy, classism, heteronormativity, and ableism. The SCA community prioritizes marginalized people’s safety over privileged people’s comfort.
 
-Participants in any SCA event or forum, online or offline, who are asked to stop any harassing behavior are expected to comply immediately. Those who violate these rules are subject to expulsion from the program or online space. Persons who have been expelled, banned, or otherwise denied access may submit an appeal to the SCA Board.[^2]
+SCA will take seriously all good-faith reports of harassment. Harassment may include, but is not limited to:
 
-[^1]: SCA Programs include conferences, workshops, events, meetings, formal mentoring relationships, and online spaces such as the West_Arch listserv. 
-[^2]: The SCA Code of Conduct is reassessed every three years.
+- abusive verbal or written comments, unwelcome jokes, discriminatory images; 
+- purposeful acts of misgendering in public or online spaces;
+- unwelcome sexual attention; 
+- comments that reinforce oppressive power dynamics related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion, national origin, or economic status;
+- deliberate intimidation; 
+- stalking; 
+- sustained disruption of talks or other events; and
+- inappropriate physical contact or invasion of physical space.
+
+Persons that have been subjected to any of the above behaviors may report that behavior anonymously to any member of the Board of SCA, the Ethics and Inclusion Committee, or member of the hosting committee, or through the online [incident report form](https://forms.gle/XbpQQc7WzwmEnyuA8).  Participants in any SCA event or forum, online or offline, who are asked to stop any harassing behavior are expected to comply immediately. Those who violate these rules are subject to expulsion from the program or online space, based on the Code of Conduct Violation Procedure. Persons who have been expelled, banned, or otherwise denied access may submit an appeal to the [Ethics and Inclusion Committee](https://calarchivists.org/Ethics-and-Inclusion) and the SCA Board^[3].
+
+[^1]: Digital Library Federation (DLF), Code of Conduct, September 2020.
+[^2]: SCA Programs include conferences, workshops, events, meetings, formal mentoring relationships, and online spaces such as the West_Arch listserv. 
+[^3]: The SCA Code of Conduct is reassessed every three years.
+
+Approved by SCA Board 2021.
+Web Archived URL for 2020 Code of Conduct [https://web.archive.org/web/20200805010640/https://calarchivists.org/CodeofConduct](https://web.archive.org/web/20200805010640/https://calarchivists.org/CodeofConduct)
 
 ***
 
-_Revision history: 01/2018 llc; 02/2018 llc; 04/2019 llc_
+_Revision history: 01/2018 llc; 02/2018 llc; 04/2019 llc; 03/2023 ck_


### PR DESCRIPTION
Bringing this page up to date with the latest Code of Conduct approved by the SCA Board in 2021. Proposed revisions now mirror the Code of Conduct as stated on the SCA website: https://calarchivists.org/CodeofConduct