### PR TITLE
Update 05-04_awards-history.md

### DIFF
--- a/05_History/05-04_awards-history.md
+++ b/05_History/05-04_awards-history.md
@@ -127,10 +127,6 @@ Scholarships are awarded each year in honor of James V. Mink, long-time archivis
 | 2021 | Gabriele Carey and Catherine Powell |
 | 2022 | Brian Tingle      |
 
-## Lynn A. Bonfield Professional Development Award (established 2018)
-
-| 2019 | Kelsi Evans   |
-
 ## Special Recognition Awards
 
 | 2003 | Metal Edge, Inc. for its continued support for SCA and its programs                          |


### PR DESCRIPTION
The section on recipients of the Lynn A. Bonfield Award was removed following discussion with the Awards Committee Chair in 4/23 when it was decided that maintaining a list of recipients of the Lynn A. Bonfield Award recipients was not necessary. Note: I did not update the revision history because this change follows so closely to the previous change made in 3/23.