### PR TITLE
Update 05-04_awards-history.md

### DIFF
--- a/05_History/05-04_awards-history.md
+++ b/05_History/05-04_awards-history.md
@@ -62,7 +62,7 @@ Sponsored by Metal Edge, Inc, the Archives Appreciation Award is presented to an
 | 2014 | Mission Inn Foundation                                           |
 | 2015 | Los Angeles County Metropolitan Transit Authority                |
 | 2016 | Computer History Museum                                          |
-| 2017 | Immaculate Heart Community                                       |
+| 2017 | Anita Caspary Archives/Immaculate Heart Community                |
 | 2018 | [not awarded]                                                    |
 | 2019 | Los Angeles Archivists Collective                                |
 | 2020 | [not awarded]                                                    |
@@ -139,4 +139,4 @@ Scholarships are awarded each year in honor of James V. Mink, long-time archivis
 
 ***
 
-_Revision history: 1/10 lo, 3/11 lo, 7/12 tep, 5/14 tep, 01/2017 llc, 06/2017 llc, 05/2019 llc, 01/2022 ck, 03/23 lm_
+_Revision history: 1/10 lo, 3/11 lo, 7/12 tep, 5/14 tep, 01/2017 llc, 06/2017 llc, 05/2019 llc, 01/2022 ck, 03/23 lm, 01/2024 jb_


### PR DESCRIPTION
Correcting: Part 5: History; section 5-4 Awards History; under Archives Appreciation Award - change the 2017 awardee from “Immaculate Heart Community” to “Anita Caspary Archives/Immaculate Heart Community”