### PR TITLE
Update 03-14-01_newsletter.md

### DIFF
--- a/03_Committees/03-14-01_newsletter.md
+++ b/03_Committees/03-14-01_newsletter.md
@@ -12,14 +12,14 @@ The SCA Newsletter is the official voice of the Society, and is overseen by the 
 Copy deadlines and publication dates are as follows:
 
 | **Copy Deadline:** | **Publication Dates:** |
-| December 1         | January 1          |
-| March 1	           | April 1            |
-| June 1	            | July 1             |
-| September 1	       | October 1          |
+| November 25        | January 1          |
+| February 25	       | April 1            |
+| May25	             | July 1             |
+| August 25 1	       | October 1          |
 
 ## Newsletter Editor
 
-The editor is appointed by the Publications Committee Chair with the approval of the Board. Co-editors may also be appointed. The editor and any co-editors are subject to the policies and procedures set by the Board.
+The editors and advertising coordinator are appointed by the Publications Committee Chair with the approval of the Board. The editors and advertising coordinator are subject to the policies and procedures set by the Board.
 
 ## Production Responsibilities
 
@@ -33,10 +33,9 @@ The editor is appointed by the Publications Committee Chair with the approval of
       - ii.	a copyright statement as follows: “Copyright [current year] by the Society of California Archivists. Requests to republish or distribute copyrighted material in the newsletter should be directed to the Chair of SCA’s Publications Committee.”
 2. Reports activities to the Publications Committee Chair in anticipation of the Board’s quarterly meetings. An annual budget for the _Newsletter_ as well as a final accounting of the past year’s expenditures and activities should be submitted to the Publications Committee Chair prior to the Board’s Fall meeting. This report will be included in the Publications Committee's annual report.
 3. Keeps records of expenses and forwards receipts to the Treasurer for reimbursement.
-4. Secures mailing labels from the Membership Chair for each issue as appropriate.
-5. Maintains a newsletter exchange with other professional associations to serve as a reference tool for the _Newsletter_ editor. The editor should review other allied organizations’ newsletters for content and format ideas.
-6. Sends non-current records, as well as a complete printed set of the past year's newsletters, to the SCA Archives.
+4. The editor should review other allied organizations’ newsletters for content and format ideas.
+5. Sends non-current records, as well as a complete printed set of the past year's newsletters, to the SCA Archives.
 
 ***
 
-_Revision history: 4/90 nlb, 1/91 nlb, 7/91 nlb, 2/92 jab, 5/93 jab, 9/04 dgh, 1/05, 3/06 Board, 06/2017 llc, 10/2017 llc, 04/2019 llc, 05/2019 llc_
+_Revision history: 4/90 nlb, 1/91 nlb, 7/91 nlb, 2/92 jab, 5/93 jab, 9/04 dgh, 1/05, 3/06 Board, 06/2017 llc, 10/2017 llc, 04/2019 llc, 05/2019 llc, 04/2024 am_


### PR DESCRIPTION
Updated copy deadlines to match the website and editor handbook.  Under newsletter editor, updated the language to reflect that we have several editors and added advertising coordinator so all roles are covered. Removed item 4 under responsibilities since we no longer mail the newsletter. Changed numbering to reflect removal of 4. Under item 5, removed language about the newsletter exchange since this doesn't actively happen since our newsletter is readily available online.